### PR TITLE
Add missing end() method for the promise pool

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -59,6 +59,7 @@ export interface Pool extends EventEmitter {
 
     getConnection(): Promise<PoolConnection>;
     on(event: 'connection', listener: (connection: PoolConnection) => any): this;
+    end(): Promise<void>;
 }
 
 export function createConnection(connectionUri: string): Connection;


### PR DESCRIPTION
The regular pool has an end() method because it extends
mysql.Connection.

The promise Pool cannot extend mysql.Connection and is therefore
missing its end() method. In the promise version, end() takes no
arguments and returns a promise that rejects if one of the
connections fails to close.