### PR TITLE
Fix to Promise CreateConnection

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -62,6 +62,6 @@ export interface Pool extends EventEmitter {
     end(): Promise<void>;
 }
 
-export function createConnection(connectionUri: string): Connection;
-export function createConnection(config: ConnectionOptions): Connection;
+export function createConnection(connectionUri: string): Promise<Connection>;
+export function createConnection(config: ConnectionOptions): Promise<Connection>;
 export function createPool(config: PoolOptions): Pool;

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -44,8 +44,6 @@ pool.execute<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution')
     });
 
 async function test() {
-    testConnections();
-
     const connection = await pool.getConnection();
     // Use the connection
     const rows = await connection.query('SELECT something FROM sometable');

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -2,23 +2,25 @@
 import * as mysql from 'mysql2/promise';
 
 // Connections
-let connection = mysql.createConnection({
-    host: 'localhost',
-    user: 'me',
-    password: 'secret'
-});
-
-connection.connect()
-    .then(() => connection.query<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution'))
-    .then(([rows, fields]) => {
-        console.log('The solution is: ', rows[0]['solution']);
+async function testConnections() {
+    let connection = await mysql.createConnection({
+        host: 'localhost',
+        user: 'me',
+        password: 'secret'
     });
 
-connection.connect()
-    .then(() => connection.execute<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution'))
-    .then(([rows, fields]) => {
-        console.log('The solution is: ', rows[0]['solution']);
-    });
+    connection.connect()
+        .then(() => connection.query<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution'))
+        .then(([rows, fields]) => {
+            console.log('The solution is: ', rows[0]['solution']);
+        });
+
+    connection.connect()
+        .then(() => connection.execute<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution'))
+        .then(([rows, fields]) => {
+            console.log('The solution is: ', rows[0]['solution']);
+        });
+}
 
 /// Pools
 
@@ -42,6 +44,8 @@ pool.execute<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution')
     });
 
 async function test() {
+    testConnections();
+
     const connection = await pool.getConnection();
     // Use the connection
     const rows = await connection.query('SELECT something FROM sometable');


### PR DESCRIPTION
This is an adjustment to the promise create connection type. It should return a Promise<Connection>. This change is based on the node-mysql2 [docs](https://github.com/sidorares/node-mysql2/blob/master/README.md#using-promise-wrapper) and [source](https://github.com/sidorares/node-mysql2/blob/b098d4969a000644d110e29b9aa0bee33cb1dfcb/promise.js#L24):

```js
async function main() {
  // get the client
  const  mysql = require('mysql2/promise');
  // create the connection
  const connection = await mysql.createConnection({host:'localhost', user: 'root', database: 'test'});
  // query database
  const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
}
```

I wasn't able to run the tests, but I adjusted them anyway. Let me know if anything doesn't work and I'll update the PR.