### PR TITLE
Add `unprepare` method to Connection interface

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -26,6 +26,8 @@ export interface Connection extends EventEmitter {
     execute<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: QueryOptions): Promise<[T, FieldPacket[]]>;
     execute<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: QueryOptions, values: any | any[] | { [param: string]: any }): Promise<[T, FieldPacket[]]>;
 
+    unprepare(sql: string): void;
+
     end(options?: any): Promise<void>;
 
     destroy(): void;


### PR DESCRIPTION
Currently this library is missing the unprepare method; this adds it to the connection here https://github.com/sidorares/node-mysql2/blob/b41de75a168f0ca2578efaf41c3524edaef7cbe7/lib/connection.js#L648