### PR TITLE
Adding missing properties to ConnectionOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,29 @@ export interface Pool extends mysql.Connection {
     on(event: 'enqueue', listener: () => any): this;
 }
 
+export interface ConnectionOptions extends mysql.ConnectionOptions {
+    charsetNumber?: number;
+    compress?: boolean;
+    authSwitchHandler?: (data: any, callback: () => void) => any;
+    connectAttributes?: { [param: string]: any };
+    decimalNumbers?: boolean;
+    isServer?: boolean;
+    maxPreparedStatements?: number;
+    namedPlaceholders?: boolean;
+    nestTables?: boolean | string;
+    passwordSha1?: string;
+    pool?: any;
+    rowsAsArray?: boolean;
+    stream?: any;
+    uri?: string;
+    connectionLimit?: number;
+    Promise?: any;
+    queueLimit?: number;
+    waitForConnections?: boolean;
+}
+
+export interface PoolOptions extends mysql.PoolOptions, ConnectionOptions {}
+
 export function createConnection(connectionUri: string): Connection;
-export function createConnection(config: mysql.ConnectionOptions): Connection;
-export function createPool(config: mysql.PoolOptions): Pool;
+export function createConnection(config: ConnectionOptions): Connection;
+export function createPool(config: PoolOptions): Pool;


### PR DESCRIPTION
This pull request adds all missing properties for the `ConnectionOption` interface.
They are mostly new properties that didn't exist in the old mysql package.

There are some exceptions where the properties did exist in the old mysql package, but where missing from types/mysql:
`charsetNumber`, `nestTables`, `pool`, `connectionLimit`, `waitConnections`

Also, I am uncertain on what these types should be defined as: `pool`, `Promise` and `stream`. These are all set as `any` right now.