### PR TITLE
Added ping() definition 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface Connection extends mysql.Connection {
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: mysql.QueryError | null, result: T, fields: mysql.FieldPacket[]) => any): mysql.Query;
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(options: mysql.QueryOptions, callback?: (err: mysql.QueryError | null, result: T, fields?: mysql.FieldPacket[]) => any): mysql.Query;
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(options: mysql.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: mysql.QueryError | null, result: T, fields: mysql.FieldPacket[]) => any): mysql.Query;
+    ping(callback?: (err: mysql.QueryError | null) => any): void;
 }
 
 export interface PoolConnection extends mysql.PoolConnection, Connection {}

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -9,11 +9,11 @@ export interface Connection extends EventEmitter {
     threadId: number;
 
     connect(): Promise<void>;
+    ping(): Promise<void>;
 
     beginTransaction(): Promise<void>;
     commit(): Promise<void>;
     rollback(): Promise<void>;
-    ping(): Promise<void>;
 
     changeUser(options: ConnectionOptions): Promise<void>;
 

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -13,6 +13,7 @@ export interface Connection extends EventEmitter {
     beginTransaction(): Promise<void>;
     commit(): Promise<void>;
     rollback(): Promise<void>;
+    ping(): Promise<void>;
 
     changeUser(options: ConnectionOptions): Promise<void>;
 

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -46,6 +46,7 @@ pool.execute<mysql.RowDataPacket[]>('SELECT 1 + 1 AS solution')
 async function test() {
     const connection = await pool.getConnection();
     // Use the connection
+    await connection.ping();
     const rows = await connection.query('SELECT something FROM sometable');
     // And done with the connection.
     connection.release();

--- a/test/test.ts
+++ b/test/test.ts
@@ -11,6 +11,7 @@ let connection = mysql.createConnection({
 });
 
 connection.connect();
+connection.ping();
 
 connection.query('SELECT 1 + 1 AS solution', function (err: mysql.QueryError, rows: mysql.RowDataPacket[], fields: mysql.FieldPacket) {
     if (err) {


### PR DESCRIPTION
The connection interface definition in `mysql` doesn't actually include ping, but it does exist on both `Connection` and `PoolConnection`

```ts
const connection = mysql2.createConnection({...});
connection.ping((error) => console.error);
```

```ts
const pool = mysql2.createPool({...});
const conn = await pool.getConnection();
try {
  await conn.ping();
} catch(error) {
  console.error(error);
}
```