### PR TITLE
Add .promise() function on pools and connections

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 
-import './promise';
+import { Connection as PromiseConnection, Pool as PromisePool, PoolConnection as PromisePoolConnection } from './promise';
 import * as mysql from 'mysql';
 export * from 'mysql';
 
@@ -9,9 +9,12 @@ export interface Connection extends mysql.Connection {
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(options: mysql.QueryOptions, callback?: (err: mysql.QueryError | null, result: T, fields?: mysql.FieldPacket[]) => any): mysql.Query;
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(options: mysql.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: mysql.QueryError | null, result: T, fields: mysql.FieldPacket[]) => any): mysql.Query;
     ping(callback?: (err: mysql.QueryError | null) => any): void;
+    promise(promiseImpl?: PromiseConstructor): PromiseConnection;
 }
 
-export interface PoolConnection extends mysql.PoolConnection, Connection {}
+export interface PoolConnection extends mysql.PoolConnection, Connection {
+    promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
+}
 
 export interface Pool extends mysql.Connection {
     execute<T extends mysql.RowDataPacket[][] | mysql.RowDataPacket[] | mysql.OkPacket | mysql.OkPacket[]>(sql: string, callback?: (err: mysql.QueryError | null, result: T, fields: mysql.FieldPacket[]) => any): mysql.Query;
@@ -23,6 +26,7 @@ export interface Pool extends mysql.Connection {
     on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
     on(event: 'release', listener: (connection: PoolConnection) => any): this;
     on(event: 'enqueue', listener: () => any): this;
+    promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
 
 export interface ConnectionOptions extends mysql.ConnectionOptions {


### PR DESCRIPTION
This allows existing callback-based instances to be wrapped with promise-based interfaces. While most users can simply import `mysql2/promise` to use only promises, using both interfaces side by side is necessary to access advanced features like streaming query results.

See https://github.com/sidorares/node-mysql2#using-promise-wrapper

Fixes #28