### PR TITLE
Add Node.js 8/10/12/latest stable to the test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
  - '6'
+ - '8'
+ - '10'
+ - '12'
+ - 'node'
 install:
  - npm install
  - typings install


### PR DESCRIPTION
Add Node.js 8/10/12/latest stable (13 at this moment) to the test environments.

See https://nodejs.org/en/about/releases/ for the currently supported versions.