### PR TITLE
Extend FieldPacket interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,10 @@ export interface ConnectionOptions extends mysql.ConnectionOptions {
 export interface PoolOptions extends mysql.PoolOptions, ConnectionOptions {}
 
 export interface FieldPacket extends mysql.FieldPacket {
-    columnType: string
+    columnType: number
+    columnLength: number
+    schema: string
+    characterSet: number
 }
 
 export function createConnection(connectionUri: string): Connection;

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,10 @@ export interface ConnectionOptions extends mysql.ConnectionOptions {
 
 export interface PoolOptions extends mysql.PoolOptions, ConnectionOptions {}
 
+export interface FieldPacket extends mysql.FieldPacket {
+    columnType: string
+}
+
 export function createConnection(connectionUri: string): Connection;
 export function createConnection(config: ConnectionOptions): Connection;
 export function createPool(config: PoolOptions): Pool;


### PR DESCRIPTION
It turns out that `mysql` and `mysql2` have different property names on a column definition. The `mysql` library's column definition (internally called a `FieldPacket`) has its properties [here](https://github.com/mysqljs/mysql/blob/master/lib/protocol/packets/FieldPacket.js#L2), and the `mysql2` library's column definition (internally called a `ColumnDefinition`) has its properties [here](https://github.com/sidorares/node-mysql2/blob/master/lib/packets/column_definition.js#L21). They differ with respect to `columnType`, `columnLength`, `schema`, and `characterSet`, so this PR extends the `FieldPacket` to add these types. This is a non breaking change.