### PR TITLE
Add missing authPlugins property to ConnectionOptions and PoolOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,22 @@ export interface Pool extends mysql.Connection {
     on(event: 'enqueue', listener: () => any): this;
 }
 
+type authPlugins =
+    (pluginMetadata: { connection: Connection; command: string }) =>
+        (pluginData: Buffer) => Promise<string>;
+
+export interface ConnectionOptions extends mysql.ConnectionOptions {
+    authPlugins?: {
+        [key: string]: authPlugins;
+    };
+}
+
+export interface PoolOptions extends mysql.PoolOptions {
+    authPlugins?: {
+        [key: string]: authPlugins;
+    };
+}
+
 export function createConnection(connectionUri: string): Connection;
-export function createConnection(config: mysql.ConnectionOptions): Connection;
-export function createPool(config: mysql.PoolOptions): Pool;
+export function createConnection(config: ConnectionOptions): Connection;
+export function createPool(config: PoolOptions): Pool;


### PR DESCRIPTION
This PR adds missing `authPlugins` property to `ConnectionOptions` as well as `PoolOptions`.

More information about `authPlugins` is available over at [sidorares/node-mysql2](https://github.com/sidorares/node-mysql2):

https://github.com/sidorares/node-mysql2/pull/1021
https://github.com/sidorares/node-mysql2/pull/1052

I'm not sure how you usually extend these interfaces as it seems like it was directly derived from `@types/mysql`  and I'm unsure about the code standards for this project. Please tell me if there's any changes needed.

Cheers
Hampus