### PR TITLE
Fixes for build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "module": "commonjs",
     "typeRoots": [
       "./typings/globals"
+    ],
+    "types": [
+      "node"
     ]
   }
 }


### PR DESCRIPTION
The errors fixed:  index.d.ts:
Cannot find namespace 'NodeJS'. ts(2503) [24,35]
Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i @types/node`. ts(2580) [66,22]