### PR TITLE
Support string as a parameter to createPool

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,4 +79,4 @@ export interface PoolOptions extends mysql.PoolOptions {
 
 export function createConnection(connectionUri: string): Connection;
 export function createConnection(config: ConnectionOptions): Connection;
-export function createPool(config: PoolOptions): Pool;
+export function createPool(config: PoolOptions | string): Pool;

--- a/test/test.ts
+++ b/test/test.ts
@@ -219,6 +219,26 @@ pool.getConnection(function (err, connection) {
     });
 });
 
+pool = mysql.createPool('https://example.org/mysql/db');
+
+pool.getConnection(function (err, connection) {
+    // connected! (unless `err` is set)
+});
+
+pool.on('connection', function (connection) {
+    connection.query('SET SESSION auto_increment_increment=1');
+});
+
+pool.getConnection(function (err, connection) {
+    // Use the connection
+    connection.query('SELECT something FROM sometable', function (err, rows) {
+        // And done with the connection.
+        connection.release();
+
+        // Don't use the connection here, it has been returned to the pool.
+    });
+});
+
 /// PoolClusters
 
 // create


### PR DESCRIPTION
I've added the ability to pass a string as a parameter to the createPool method as the code itself allows this.

I'd like to come back and refresh this library and bring things up-to-date when I have some time soon.